### PR TITLE
Use IP address instead of hostname

### DIFF
--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
           - name: SCHEMA_REGISTRY_HOST_NAME
             valueFrom:
               fieldRef:
-                fieldPath: metadata.name
+                fieldPath: status.podIP
           - name: SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
             value: {{ template "schema-registry.kafkaStore.bootstrapServers" . }}
           - name: SCHEMA_REGISTRY_KAFKASTORE_GROUP_ID


### PR DESCRIPTION
Use IP address instead of the hostname for SCHEMA_REGISTRY_HOST_NAME.  Since internal DNS for pods can be disabled,  the slave might not be able to communicate to master.